### PR TITLE
Update headers

### DIFF
--- a/cron/package-stats.php
+++ b/cron/package-stats.php
@@ -1,25 +1,29 @@
 #!/usr/local/bin/php -Cq
 <?php
+
 /*
-* +----------------------------------------------------------------------+
-* | PEAR Web site version 1.0                                            |
-* +----------------------------------------------------------------------+
-* | Copyright (c) 2001 The PHP Group                                     |
-* +----------------------------------------------------------------------+
-* | This source file is subject to version 2.02 of the PHP license,      |
-* | that is bundled with this package in the file LICENSE, and is        |
-* | available at through the world-wide-web at                           |
-* | https://php.net/license/2_02.txt.                                    |
-* | If you did not receive a copy of the PHP license and are unable to   |
-* | obtain it through the world-wide-web, please send a note to          |
-* | license@php.net so we can mail you a copy immediately.               |
-* +----------------------------------------------------------------------+
-* | Authors: Richard Heyes <richard@php.net>                             |
-* +----------------------------------------------------------------------+
-*
-* This short script populates the package_stats table and should be run
-* via cron.
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Richard Heyes <richard@php.net>                             |
+  +----------------------------------------------------------------------+
 */
+
+/**
+ * This short script populates the package_stats table and should be run
+ * via cron.
+ */
+
 	require_once('DB.php');
 /**
 * DSN for pear packages database

--- a/cron/update-win-pkg-cache.php
+++ b/cron/update-win-pkg-cache.php
@@ -1,10 +1,23 @@
 #!/usr/local/bin/php -Cq
 <?php
-/* vim: set expandtab tabstop=4 shiftwidth=4; */
-// +---------------------------------------------------------------------+
-// |  Authors:  Anatol Belski <ab@php.net>                               |
-// +---------------------------------------------------------------------+
-//
+
+/*
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Anatol Belski <ab@php.net>                                  |
+  +----------------------------------------------------------------------+
+*/
 
 require_once __DIR__ . '/../include/pear-prepend.php';
 
@@ -19,7 +32,7 @@ if (DB::isError($dbh)) {
 }
 $dbh->query('SET NAMES utf8');
 
-$data = $dbh->getAll("SELECT packages.name, releases.version, releases.releasedate 
+$data = $dbh->getAll("SELECT packages.name, releases.version, releases.releasedate
 						FROM packages, releases
 						WHERE packages.id = releases.package",
 					NULL,

--- a/generatePECL_REST.php
+++ b/generatePECL_REST.php
@@ -1,8 +1,27 @@
 <?php
+
+/*
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Greg Beaver <cellog@php.net>                                |
+  +----------------------------------------------------------------------+
+*/
+
 /**
  * Generate static REST files for pecl.php.net from existing data
- * @author Greg Beaver <cellog@php.net>
  */
+
 /**
  * Useful files to have
  */

--- a/include/Damblan/Karma.php
+++ b/include/Damblan/Karma.php
@@ -1,20 +1,21 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2003 The PEAR Group                                    |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Author: Martin Jansen <mj@php.net>                                   |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Martin Jansen <mj@php.net>                                  |
+  +----------------------------------------------------------------------+
 */
 
 /**
@@ -23,9 +24,6 @@
  * This system makes it not only possible to provide a fully developed
  * permission system, but it also allows us to set up a php.net-wide
  * single-sign-on system some time in the future.
- *
- * @author  Martin Jansen <mj@php.net>
- * @version $Revision$
  */
 class Damblan_Karma {
 

--- a/include/layout.php
+++ b/include/layout.php
@@ -1,20 +1,21 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001 The PHP Group                                     |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors:                                                             |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
 */
 
 // spacer()

--- a/include/pear-auth.php
+++ b/include/pear-auth.php
@@ -1,20 +1,21 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2003 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors:                                                             |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
 */
 
 function auth_reject($realm = null, $message = null)

--- a/include/pear-config.php
+++ b/include/pear-config.php
@@ -1,20 +1,21 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2003 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors:                                                             |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
 */
 
 if (isset($_SERVER['PEAR_TMPDIR'])) {

--- a/include/pear-database.php
+++ b/include/pear-database.php
@@ -1,23 +1,25 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2005 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors: Stig Bakken <ssb@fast.no>                                   |
-   |          Tomas V.V.Cox <cox@php.net>                                 |
-   |          Martin Jansen <mj@php.net>                                  |
-   |          Gregory Beaver <cellog@php.net>                             |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Stig S. Bakken <ssb@fast.no>                                |
+  |          Tomas V.V.Cox <cox@php.net>                                 |
+  |          Martin Jansen <mj@php.net>                                  |
+  |          Gregory Beaver <cellog@php.net>                             |
+  |          Richard Heyes <richard@php.net>                             |
+  +----------------------------------------------------------------------+
 */
 
 require_once 'DB/storage.php';
@@ -129,10 +131,6 @@ function version_compare_firstelem($a, $b)
  *
  * @class   category
  * @package pearweb
- * @author  Stig S. Bakken <ssb@fast.no>
- * @author  Tomas V.V. Cox <cox@php.net>
- * @author  Martin Jansen <mj@php.net>
- * @author  Richard Heyes <richard@php.net>
  */
 class category
 {
@@ -332,9 +330,6 @@ class category
  *
  * @class   package
  * @package pearweb
- * @author  Stig S. Bakken <ssb@fast.no>
- * @author  Tomas V.V. Cox <cox@php.net>
- * @author  Martin Jansen <mj@php.net>
  */
 class package
 {
@@ -1212,9 +1207,6 @@ class package
  *
  * @class   maintainer
  * @package pearweb
- * @author  Stig S. Bakken <ssb@fast.no>
- * @author  Tomas V.V. Cox <cox@php.net>
- * @author  Martin Jansen <mj@php.net>
  */
 class maintainer
 {
@@ -1466,9 +1458,6 @@ class maintainer
  *
  * @class   release
  * @package pearweb
- * @author  Stig S. Bakken <ssb@fast.no>
- * @author  Tomas V.V. Cox <cox@php.net>
- * @author  Martin Jansen <mj@php.net>
  */
 class release
 {
@@ -2267,9 +2256,6 @@ Authors
  *
  * @class   note
  * @package pearweb
- * @author  Stig S. Bakken <ssb@fast.no>
- * @author  Tomas V.V. Cox <cox@php.net>
- * @author  Martin Jansen <mj@php.net>
  */
 class note
 {

--- a/include/pear-format-html.php
+++ b/include/pear-format-html.php
@@ -1,20 +1,21 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2006 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors:                                                             |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
 */
 
 /* Send charset */

--- a/include/pear-prepend.php
+++ b/include/pear-prepend.php
@@ -1,21 +1,23 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2005 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors:                                                             |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
 */
+
 require_once "pear-config.php";
 
 // silence the notices for production

--- a/include/pear-rest.php
+++ b/include/pear-rest.php
@@ -1,4 +1,23 @@
 <?php
+
+/*
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
+*/
+
 class pear_rest
 {
     var $_restdir;
@@ -232,7 +251,7 @@ class pear_rest
                 strtolower($package['name'])]);
             @chmod($pdir . DIRECTORY_SEPARATOR . strtolower($package['name']), 0777);
         }
-        $catinfo = $dbh->getOne('SELECT c.name FROM packages, categories c WHERE 
+        $catinfo = $dbh->getOne('SELECT c.name FROM packages, categories c WHERE
             c.id = ?', [$package['categoryid']], DB_FETCHMODE_ASSOC);
         if (isset($package['parent']) && $package['parent']) {
             $parent = '

--- a/include/pear-win-package.php
+++ b/include/pear-win-package.php
@@ -1,20 +1,21 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2005 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors: Anatol Belski <ab@php.net>                                  |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Anatol Belski <ab@php.net>                                  |
+  +----------------------------------------------------------------------+
 */
 
 define("PECL_DLL_URL_CACHE_DB", PEAR_TMPDIR . DIRECTORY_SEPARATOR . "pecl_dll_url.cache");

--- a/include/posttohost.php
+++ b/include/posttohost.php
@@ -1,10 +1,27 @@
 <?php
 
 /*
- This code is used to post data to the central server which
- can store the data in database and/or mail notices or requests
- to PHP.net stuff and servers
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
 */
+
+/**
+ * This code is used to post data to the central server which can store the data
+ * in database and/or mail notices or requests to PHP.net stuff and servers.
+ */
 
 function posttohost($url, $data)
 {

--- a/include/renum.php
+++ b/include/renum.php
@@ -1,20 +1,21 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2003 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors:                                                             |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
 */
 
 require_once "pear-config.php";

--- a/public_html/about/damblan.php
+++ b/public_html/about/damblan.php
@@ -1,21 +1,23 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2003 The PEAR Group                                    |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors: Martin Jansen <mj@php.net>                                  |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Martin Jansen <mj@php.net>                                  |
+  +----------------------------------------------------------------------+
 */
+
 response_header("Damblan");
 ?>
 

--- a/public_html/about/index.php
+++ b/public_html/about/index.php
@@ -1,21 +1,23 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2003 The PEAR Group                                    |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors: Martin Jansen <mj@php.net>                                  |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Martin Jansen <mj@php.net>                                  |
+  +----------------------------------------------------------------------+
 */
+
 response_header("About this site");
 ?>
 

--- a/public_html/about/privacy.php
+++ b/public_html/about/privacy.php
@@ -1,21 +1,23 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2003 The PEAR Group                                    |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors: Martin Jansen <mj@php.net>                                  |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Martin Jansen <mj@php.net>                                  |
+  +----------------------------------------------------------------------+
 */
+
 response_header("Privacy Policy");
 ?>
 

--- a/public_html/account-edit.php
+++ b/public_html/account-edit.php
@@ -1,20 +1,21 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2005 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors:                                                             |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
 */
 
 auth_require();

--- a/public_html/account-info.php
+++ b/public_html/account-info.php
@@ -1,20 +1,21 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2003 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors:                                                             |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
 */
 
 /**

--- a/public_html/account-mail.php
+++ b/public_html/account-mail.php
@@ -1,20 +1,21 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2003 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors:                                                             |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
 */
 
 /**

--- a/public_html/account-request.php
+++ b/public_html/account-request.php
@@ -1,20 +1,21 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2003 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors:                                                             |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
 */
 
 require_once "HTML/Form.php";
@@ -126,7 +127,7 @@ if (isset($_POST['submit'])) {
             // the user's "userinfo" column
             $userinfo = serialize([$purpose, $moreinfo]);
             $created_at = gmdate('Y-m-d H:i');
-            $sth = $dbh->prepare("INSERT INTO users 
+            $sth = $dbh->prepare("INSERT INTO users
                     (handle, name, email, password, registered, showemail, homepage, userinfo, from_site, active, created)
                     VALUES(?, ?, ?, ?, 0, ?, ?, ?, 'pecl', 0, ?)");
             $res = $dbh->execute($sth, [$handle, $name, $email, $hash, $showemail, $homepage, $userinfo, $created_at]);

--- a/public_html/accounts.php
+++ b/public_html/accounts.php
@@ -1,20 +1,21 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2003 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors:                                                             |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
 */
 
 response_header("Accounts");

--- a/public_html/admin/apc.php
+++ b/public_html/admin/apc.php
@@ -1,9 +1,10 @@
 <?php
+
 /*
   +----------------------------------------------------------------------+
-  | APC                                                                  |
+  | The PECL website                                                     |
   +----------------------------------------------------------------------+
-  | Copyright (c) 2006 The PHP Group                                     |
+  | Copyright (c) 1999-2018 The PHP Group                                |
   +----------------------------------------------------------------------+
   | This source file is subject to version 3.01 of the PHP license,      |
   | that is bundled with this package in the file LICENSE, and is        |
@@ -17,10 +18,7 @@
   |          Rasmus Lerdorf <rasmus@php.net>                             |
   |          Ilia Alshanetsky <ilia@prohost.org>                         |
   +----------------------------------------------------------------------+
-
-   All other licensing and usage conditions are those of the PHP Group.
-
- */
+*/
 
 ////////// READ OPTIONAL CONFIGURATION FILE ////////////
 if (file_exists("apc.conf.php")) include("apc.conf.php");
@@ -1225,7 +1223,7 @@ EOB;
 			echo '<div class="ok">You are running the latest version of APC ('.$apcversion.')</div>';
 			$i = 3;
 		} else {
-			echo '<div class="failed">You are running an older version of APC ('.$apcversion.'), 
+			echo '<div class="failed">You are running an older version of APC ('.$apcversion.'),
 				newer version '.$match[1].' is available at <a href="https://pecl.php.net/package/APC/'.$match[1].'">
 				https://pecl.php.net/package/APC/'.$match[1].'</a>
 				</div>';

--- a/public_html/admin/category-manager.php
+++ b/public_html/admin/category-manager.php
@@ -1,20 +1,21 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2003 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors: Richard Heyes                                               |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Richard Heyes <richard@php.net>                             |
+  +----------------------------------------------------------------------+
 */
 
 auth_require(true);

--- a/public_html/admin/index.php
+++ b/public_html/admin/index.php
@@ -1,20 +1,21 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2003 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors: Martin Jansen <mj@php.net>                                  |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Martin Jansen <mj@php.net>                                  |
+  +----------------------------------------------------------------------+
 */
 
 auth_require(true);

--- a/public_html/admin/package-maintainers.php
+++ b/public_html/admin/package-maintainers.php
@@ -1,20 +1,21 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2003 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors: Martin Jansen <mj@php.net>                                  |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Martin Jansen <mj@php.net>                                  |
+  +----------------------------------------------------------------------+
 */
 
 require_once "HTML/Form.php";

--- a/public_html/bugs/bug.php
+++ b/public_html/bugs/bug.php
@@ -1,4 +1,23 @@
 <?php
+
+/*
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
+*/
+
 $bugs = [
   5 => '55880',
   11 => '55881',

--- a/public_html/bugs/index.php
+++ b/public_html/bugs/index.php
@@ -1,19 +1,28 @@
 <?php
+
+/*
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
+*/
+
 /**
  * The bug system home page
  *
- * This source file is subject to version 3.0 of the PHP license,
- * that is bundled with this package in the file LICENSE, and is
- * available through the world-wide-web at the following URI:
- * https://php.net/license/3_0.txt.
- * If you did not receive a copy of the PHP license and are unable to
- * obtain it through the world-wide-web, please send a note to
- * license@php.net so we can mail you a copy immediately.
- *
  * @category  pearweb
  * @package   Bugs
- * @copyright Copyright (c) 1997-2012 The PHP Group
- * @license   https://php.net/license/3_0.txt  PHP License
  */
 
 response_header('Bugs');

--- a/public_html/copyright.php
+++ b/public_html/copyright.php
@@ -1,20 +1,21 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2003 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors:                                                             |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
 */
 
 response_header("Copyright and License");

--- a/public_html/credits.php
+++ b/public_html/credits.php
@@ -1,20 +1,21 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2003 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors:                                                             |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
 */
 
 response_header('Credits');

--- a/public_html/doc/branches.php
+++ b/public_html/doc/branches.php
@@ -1,4 +1,23 @@
 <?php
+
+/*
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
+*/
+
 response_header("CVS Branches and how they relate to PECL");
 ?>
 

--- a/public_html/doc/index.php
+++ b/public_html/doc/index.php
@@ -1,4 +1,23 @@
 <?php
+
+/*
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
+*/
+
 response_header("PECL specific docs");
 ?>
 

--- a/public_html/dtd/index.php
+++ b/public_html/dtd/index.php
@@ -1,20 +1,21 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2003 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors: Martin Jansen <mj@php.net>                                  |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Martin Jansen <mj@php.net>                                  |
+  +----------------------------------------------------------------------+
 */
 
 response_header("Document Type Definitions");

--- a/public_html/dtd/package-1.0
+++ b/public_html/dtd/package-1.0
@@ -1,17 +1,16 @@
 <!--
-     $Id$
 
      This is the PEAR package description, version 1.0b3.
      It should be used with the informal public identifier:
 
          "-//PHP Group//DTD PEAR Package 1.0b3//EN//XML"
 
-     Copyright (c) 1997-2003 The PHP Group
+     Copyright (c) 1999-2018 The PHP Group
 
-     This source file is subject to version 2.02 of the PHP license,
+     This source file is subject to version 3.01 of the PHP license,
      that is bundled with this package in the file LICENSE, and is
-     available at through the world-wide-web at
-     https://php.net/license/2_02.txt.
+     available through the world-wide-web at the following url:
+     https://php.net/license/3_01.txt
      If you did not receive a copy of the PHP license and are unable to
      obtain it through the world-wide-web, please send a note to
      license@php.net so we can mail you a copy immediately.

--- a/public_html/dtd/package-1.1
+++ b/public_html/dtd/package-1.1
@@ -1,17 +1,16 @@
 <!--
-     $Id$
 
      This is the PEAR package description, version 1.0b3.
      It should be used with the informal public identifier:
 
          "-//PHP Group//DTD PEAR Package 1.0b3//EN//XML"
 
-     Copyright (c) 1997-2003 The PHP Group
+     Copyright (c) 1999-2018 The PHP Group
 
-     This source file is subject to version 2.02 of the PHP license,
+     This source file is subject to version 3.01 of the PHP license,
      that is bundled with this package in the file LICENSE, and is
-     available at through the world-wide-web at
-     https://php.net/license/2_02.txt.
+     available through the world-wide-web at the following url:
+     https://php.net/license/3_01.txt
      If you did not receive a copy of the PHP license and are unable to
      obtain it through the world-wide-web, please send a note to
      license@php.net so we can mail you a copy immediately.

--- a/public_html/error/404-manual.php
+++ b/public_html/error/404-manual.php
@@ -1,4 +1,26 @@
-<?php response_header("Error 404"); ?>
+<?php
+
+/*
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
+*/
+
+response_header("Error 404");
+
+?>
 
 <h2>Error 404 - document not found</h2>
 

--- a/public_html/error/404.php
+++ b/public_html/error/404.php
@@ -1,20 +1,21 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2003 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors:                                                             |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
 */
 
 /**

--- a/public_html/export.php
+++ b/public_html/export.php
@@ -1,20 +1,21 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2003 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors:                                                             |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
 */
 
 exit;

--- a/public_html/feeds/feeds.php
+++ b/public_html/feeds/feeds.php
@@ -1,20 +1,21 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2006 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/3_01.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors: Pierre-Alain Joye <pajoye@php.net>                          |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Pierre-Alain Joye <pajoye@php.net>                          |
+  +----------------------------------------------------------------------+
 */
 
 function rss_bailout() {

--- a/public_html/feeds/index.php
+++ b/public_html/feeds/index.php
@@ -1,21 +1,23 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2003 The PEAR Group                                    |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors: Martin Jansen <mj@php.net>                                  |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Martin Jansen <mj@php.net>                                  |
+  +----------------------------------------------------------------------+
 */
+
 response_header("Syndication feeds");
 ?>
 

--- a/public_html/fixdeps.php
+++ b/public_html/fixdeps.php
@@ -1,20 +1,21 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2003 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors:                                                             |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
 */
 
 require_once "PEAR/Common.php";

--- a/public_html/fixtree.php
+++ b/public_html/fixtree.php
@@ -1,21 +1,23 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2003 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors:                                                             |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
 */
+
 auth_require(true);
 
 header("Content-type: text/plain");

--- a/public_html/get
+++ b/public_html/get
@@ -1,20 +1,21 @@
-<?php // -*- PHP -*-
+<?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2003 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors:                                                             |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
 */
 
 /**

--- a/public_html/index.php
+++ b/public_html/index.php
@@ -1,20 +1,21 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2003 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors: Martin Jansen <mj@php.net>                                  |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Martin Jansen <mj@php.net>                                  |
+  +----------------------------------------------------------------------+
 */
 
 $recent = release::getRecent();

--- a/public_html/javascript/package-maintainers.js
+++ b/public_html/javascript/package-maintainers.js
@@ -1,18 +1,20 @@
-// +----------------------------------------------------------------------+
-// | PEAR Web site version 1.0                                            |
-// +----------------------------------------------------------------------+
-// | Copyright (c) 2001-2003 The PHP Group                                |
-// +----------------------------------------------------------------------+
-// | This source file is subject to version 2.02 of the PHP license,      |
-// | that is bundled with this package in the file LICENSE, and is        |
-// | available at through the world-wide-web at                           |
-// | https://php.net/license/2_02.txt.                                    |
-// | If you did not receive a copy of the PHP license and are unable to   |
-// | obtain it through the world-wide-web, please send a note to          |
-// | license@php.net so we can mail you a copy immediately.               |
-// +----------------------------------------------------------------------+
-// | Authors: Martin Jansen <mj@php.net>                                  |
-// +----------------------------------------------------------------------+
+/*
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Martin Jansen <mj@php.net>                                  |
+  +----------------------------------------------------------------------+
+*/
 
 function stripName(name) {
     pos = name.indexOf("(");

--- a/public_html/json.php
+++ b/public_html/json.php
@@ -1,20 +1,21 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2012 The PHP Group                                     |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors: Pierre Joye <pierre@php.net>                                |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Pierre Joye <pierre@php.net>                                |
+  +----------------------------------------------------------------------+
 */
 
 /* only support package maintainer for now, needed for bugs.php.net */

--- a/public_html/login.php
+++ b/public_html/login.php
@@ -1,20 +1,21 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2003 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors:                                                             |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
 */
 
 /*

--- a/public_html/logout.php
+++ b/public_html/logout.php
@@ -1,20 +1,21 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2003 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors:                                                             |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
 */
 
 if (isset($showmsg)) {

--- a/public_html/manual/index.php
+++ b/public_html/manual/index.php
@@ -1,4 +1,23 @@
 <?php
+
+/*
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
+*/
+
 response_header("PECL Documentation has Moved");
 ?>
 

--- a/public_html/news/index.php
+++ b/public_html/news/index.php
@@ -1,20 +1,21 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2003 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors: Martin Jansen <mj@php.net>                                  |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Martin Jansen <mj@php.net>                                  |
+  +----------------------------------------------------------------------+
 */
 
 response_header("News");

--- a/public_html/package-changelog.php
+++ b/public_html/package-changelog.php
@@ -1,20 +1,21 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2003 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors:                                                             |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
 */
 
 // expected url vars: pacid package

--- a/public_html/package-delete.php
+++ b/public_html/package-delete.php
@@ -1,20 +1,21 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2005 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors:                                                             |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
 */
 
 /**

--- a/public_html/package-edit.php
+++ b/public_html/package-edit.php
@@ -1,20 +1,21 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2003 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors:                                                             |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
 */
 
 /**

--- a/public_html/package-info-win.php
+++ b/public_html/package-info-win.php
@@ -1,21 +1,22 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2003 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors: Martin Jansen <mj@php.net>                                  |
-   |          Tomas V.V.Cox <cox@idecnet.com>                             |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Martin Jansen <mj@php.net>                                  |
+  |          Tomas V.V.Cox <cox@idecnet.com>                             |
+  +----------------------------------------------------------------------+
 */
 
 $package = filter_input(INPUT_GET, 'package', FILTER_SANITIZE_STRING);

--- a/public_html/package-info.php
+++ b/public_html/package-info.php
@@ -1,21 +1,22 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2003 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors: Martin Jansen <mj@php.net>                                  |
-   |          Tomas V.V.Cox <cox@idecnet.com>                             |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Martin Jansen <mj@php.net>                                  |
+  |          Tomas V.V.Cox <cox@idecnet.com>                             |
+  +----------------------------------------------------------------------+
 */
 
 $package = filter_input(INPUT_GET, 'package', FILTER_SANITIZE_STRING);

--- a/public_html/package-new.php
+++ b/public_html/package-new.php
@@ -1,20 +1,21 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2003 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors:                                                             |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
 */
 
 require_once "HTML/Form.php";

--- a/public_html/package-search.php
+++ b/public_html/package-search.php
@@ -1,21 +1,22 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2003 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors: Richard Heyes <richard@php.net>                             |
-   |          Martin Jansen <mj@php.net>                                  |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Richard Heyes <richard@php.net>                             |
+  |          Martin Jansen <mj@php.net>                                  |
+  +----------------------------------------------------------------------+
 */
 
 /**

--- a/public_html/package-stats-graph.php
+++ b/public_html/package-stats-graph.php
@@ -1,20 +1,21 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2003 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors: Richard Heyes <richard@php.net>                             |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Richard Heyes <richard@php.net>                             |
+  +----------------------------------------------------------------------+
 */
 
 /**

--- a/public_html/package-stats.php
+++ b/public_html/package-stats.php
@@ -1,22 +1,23 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2003 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors: Martin Jansen <mj@php.net>                                  |
-   |          Richard Heyes <richard@php.net>                             |
-   +----------------------------------------------------------------------+
- */
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Martin Jansen <mj@php.net>                                  |
+  |          Richard Heyes <richard@php.net>                             |
+  +----------------------------------------------------------------------+
+*/
 
 require_once 'HTML/Form.php';
 
@@ -313,8 +314,8 @@ if (isset($_GET['pid']) && (int)$_GET['pid']) {
 	$total_categories  = $dbh->getOne(sprintf("SELECT COUNT(*) FROM categories WHERE parent = %d", $_GET['cid']));
 
 	// Query to get package list from package_stats_table
-	$query = sprintf("SELECT SUM(ps.dl_number) AS dl_number, ps.package, ps.release, ps.pid, ps.rid, ps.cid 
-	                  FROM package_stats ps, packages p 
+	$query = sprintf("SELECT SUM(ps.dl_number) AS dl_number, ps.package, ps.release, ps.pid, ps.rid, ps.cid
+	                  FROM package_stats ps, packages p
 	                  WHERE p.package_type = 'pecl' AND p.id = ps.pid AND
 	                  p.category = %s GROUP BY ps.pid ORDER BY ps.dl_number DESC",
                      $_GET['cid']
@@ -332,7 +333,7 @@ if (isset($_GET['pid']) && (int)$_GET['pid']) {
 	$total_categories  = number_format($dbh->getOne('SELECT COUNT(*) FROM categories'), 0, '.', ',');
     $total_downloads   = number_format($dbh->getOne('SELECT SUM(dl_number) FROM package_stats, packages p
                        WHERE package_stats.pid = p.id AND p.package_type="pecl"'), 0, '.', ',');
-	$query             = "SELECT sum(ps.dl_number) as dl_number, ps.package, ps.pid, ps.rid, ps.cid 
+	$query             = "SELECT sum(ps.dl_number) as dl_number, ps.package, ps.pid, ps.rid, ps.cid
 	                      FROM package_stats ps, packages p
 	                      WHERE p.id = ps.pid AND p.package_type = 'pecl'
 	                      GROUP BY ps.pid ORDER BY dl_number DESC";

--- a/public_html/packages.php
+++ b/public_html/packages.php
@@ -1,20 +1,21 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2005 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors: Richard Heyes                                               |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Richard Heyes <richard@php.net>                             |
+  +----------------------------------------------------------------------+
 */
 
 /**

--- a/public_html/release-upload.php
+++ b/public_html/release-upload.php
@@ -1,20 +1,21 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2005 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors:                                                             |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
 */
 
 auth_require('pear.dev');

--- a/public_html/search.php
+++ b/public_html/search.php
@@ -1,20 +1,21 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2003 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors:                                                             |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
 */
 
 if (!isset($_POST['search_in'])) {

--- a/public_html/support.php
+++ b/public_html/support.php
@@ -1,20 +1,21 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2003 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors:                                                             |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
 */
 
 $SIDEBAR_DATA='';

--- a/public_html/takeover.php
+++ b/public_html/takeover.php
@@ -1,20 +1,21 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2003 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors:                                                             |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
 */
 
 $SIDEBAR_DATA='';

--- a/public_html/wishlist.php
+++ b/public_html/wishlist.php
@@ -1,21 +1,23 @@
 <?php
+
 /*
-   +----------------------------------------------------------------------+
-   | PEAR Web site version 1.0                                            |
-   +----------------------------------------------------------------------+
-   | Copyright (c) 2001-2003 The PHP Group                                |
-   +----------------------------------------------------------------------+
-   | This source file is subject to version 2.02 of the PHP license,      |
-   | that is bundled with this package in the file LICENSE, and is        |
-   | available at through the world-wide-web at                           |
-   | https://php.net/license/2_02.txt.                                    |
-   | If you did not receive a copy of the PHP license and are unable to   |
-   | obtain it through the world-wide-web, please send a note to          |
-   | license@php.net so we can mail you a copy immediately.               |
-   +----------------------------------------------------------------------+
-   | Authors:                                                             |
-   +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
 */
+
 if (empty($user)) {
     $user = @$_GET['handle'];
 }

--- a/script/cleanup_user.php
+++ b/script/cleanup_user.php
@@ -1,8 +1,26 @@
 #!/usr/bin/env php
 <?php
+
 /*
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Pierre Joye <pierre@php.net>                                |
+  +----------------------------------------------------------------------+
+*/
+
+/**
  * Drop all accounts not active in any package and not having a SVN account
- * Author: pierre@php.net
  */
 
 include __DIR__ . '/../include/pear-config.php';

--- a/script/drop_unused_tables.php
+++ b/script/drop_unused_tables.php
@@ -1,8 +1,27 @@
 #!/usr/bin/env php
 <?php
+
 /*
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Pierre Joye <pierre@php.net>                                |
+  +----------------------------------------------------------------------+
+*/
+
+
+/**
  * Drop unused tables
- * Author: pierre@php.net
  */
 
 include __DIR__ . '/../include/pear-config.php';

--- a/script/update_karma.php
+++ b/script/update_karma.php
@@ -1,8 +1,26 @@
 #!/usr/bin/env php
 <?php
+
 /*
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Pierre Joye <pierre@php.net>                                |
+  +----------------------------------------------------------------------+
+*/
+
+/**
  * Drop all karma not used by pecl and migrate pecl/pear.* to * only
- * Author: pierre@php.net
  */
 
 include __DIR__ . '/../include/pear-config.php';

--- a/script/update_vcs_link.php
+++ b/script/update_vcs_link.php
@@ -1,5 +1,24 @@
 #!/usr/bin/env php
 <?php
+
+/*
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Pierre Joye <pierre@php.net>                                |
+  +----------------------------------------------------------------------+
+*/
+
 include __DIR__ . '/../include/pear-config.php';
 
 $sql_movetosvn = "UPDATE packages SET cvs_link =

--- a/sql/Makefile
+++ b/sql/Makefile
@@ -1,21 +1,18 @@
-#
 # +----------------------------------------------------------------------+
-# | PHP version 4.0                                                      |
+# | The PECL website                                                     |
 # +----------------------------------------------------------------------+
-# | Copyright (c) 1999, 2000 The PHP Group                               |
+# | Copyright (c) 1999-2018 The PHP Group                                |
 # +----------------------------------------------------------------------+
-# | This source file is subject to version 2.02 of the PHP license,      |
+# | This source file is subject to version 3.01 of the PHP license,      |
 # | that is bundled with this package in the file LICENSE, and is        |
-# | available at through the world-wide-web at                           |
-# | https://php.net/license/2_02.txt.                                    |
+# | available through the world-wide-web at the following url:           |
+# | https://php.net/license/3_01.txt                                     |
 # | If you did not receive a copy of the PHP license and are unable to   |
 # | obtain it through the world-wide-web, please send a note to          |
 # | license@php.net so we can mail you a copy immediately.               |
 # +----------------------------------------------------------------------+
-# | Authors: Stig Bakken <ssb@fast.no>                                   |
-# |                                                                      |
+# | Authors: Stig S. Bakken <ssb@fast.no>                                |
 # +----------------------------------------------------------------------+
-#
 
 TABLE_FILES=\
 	aggregated_package_stats.sql \

--- a/sql/addacls.php
+++ b/sql/addacls.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
+*/
+
 require_once "DB.php";
 
 $acl_paths = [];

--- a/sql/addcategories.php
+++ b/sql/addcategories.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
+*/
+
 print "Adding categories...\n";
 
 $dbh->expectError(DB_ERROR_NOSUCHTABLE);

--- a/sql/addpackages.php
+++ b/sql/addpackages.php
@@ -1,4 +1,23 @@
 <?php
+
+/*
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
+*/
+
 print "Adding packages...\n";
 
 // Drops all packages and adds sample packages

--- a/sql/addusers.php
+++ b/sql/addusers.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
+*/
+
 print "Adding users...\n";
 
 $hardcoded_users = '

--- a/sql/create2drop
+++ b/sql/create2drop
@@ -1,5 +1,21 @@
 #!/usr/bin/perl -s
 
+# +----------------------------------------------------------------------+
+# | The PECL website                                                     |
+# +----------------------------------------------------------------------+
+# | Copyright (c) 1999-2018 The PHP Group                                |
+# +----------------------------------------------------------------------+
+# | This source file is subject to version 3.01 of the PHP license,      |
+# | that is bundled with this package in the file LICENSE, and is        |
+# | available through the world-wide-web at the following url:           |
+# | https://php.net/license/3_01.txt                                     |
+# | If you did not receive a copy of the PHP license and are unable to   |
+# | obtain it through the world-wide-web, please send a note to          |
+# | license@php.net so we can mail you a copy immediately.               |
+# +----------------------------------------------------------------------+
+# | Authors:                                                             |
+# +----------------------------------------------------------------------+
+
 if ($mysql) {
     $dbtype = "mysql";
     $transactions = 0;

--- a/sql/data.php
+++ b/sql/data.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
+*/
+
 require_once "../include/pear-prepend.php";
 require_once "DB.php";
 require_once "../include/pear-database.php";

--- a/templates/category-manager.php
+++ b/templates/category-manager.php
@@ -1,4 +1,26 @@
-<?php response_header(); ?>
+<?php
+
+/*
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
+*/
+
+response_header();
+
+?>
 
 <script src="/javascript/TreeMenu/TreeMenu.js"></script>
 <script>

--- a/templates/package-search.php
+++ b/templates/package-search.php
@@ -1,4 +1,23 @@
 <?php
+
+/*
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
+*/
+
 $extra_styles[] = '/javascript/calendar/dynCalendar.css';
 response_header('Package Search');
 ?>

--- a/templates/packages.php
+++ b/templates/packages.php
@@ -1,3 +1,25 @@
+<?php
+
+/*
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
+*/
+
+?>
+
 <script>
 	function toggleMoreInfo(packageName, packageID)
 	{


### PR DESCRIPTION
This patch syncs and updates all headers in source code files across the
PECL website code base.

- Authors preserved
- The PECL website titles used and synced as is the current project name
- PHP License version updated to the latest
- Year ranges synced
- Comment block synced as is used in php-src files - simplified
  multiline comment block.