### PR TITLE
Refactor package_dll class

### DIFF
--- a/cron/update-win-pkg-cache.php
+++ b/cron/update-win-pkg-cache.php
@@ -33,15 +33,15 @@ $data = $dbh->getAll("SELECT packages.name, releases.version, releases.releaseda
 					NULL,
 					DB_FETCHMODE_ASSOC);
 
-if (package_dll::isResetOverdue()) {
-	if (!package_dll::resetDllDownloadCache()) {
+if (PackageDll::isResetOverdue()) {
+	if (!PackageDll::resetDllDownloadCache()) {
 		/* some reset running, just sleep and do our thing*/
 		sleep(10);
 	}
 }
 
 foreach ($data as $pkg) {
-	if (!package_dll::updateDllDownloadCache($pkg['name'], $pkg['version'])) {
+	if (!PackageDll::updateDllDownloadCache($pkg['name'], $pkg['version'])) {
 		echo "Failed to update cache for $pkg[name]-$pkg[version]\n";
 	}
 }

--- a/include/pear-prepend.php
+++ b/include/pear-prepend.php
@@ -36,7 +36,7 @@ include_once "DB/storage.php";
 include_once "pear-auth.php";
 include_once "pear-database.php";
 include_once __DIR__.'/../src/Rest.php';
-include_once "pear-win-package.php";
+include_once __DIR__.'/../src/PackageDll.php';
 
 function get($name)
 {

--- a/public_html/package-info-win.php
+++ b/public_html/package-info-win.php
@@ -223,14 +223,14 @@ echo '<div>&nbsp;</div>';
 if ($version) {
 	$bb = new BorderBox("DLL List", "90%", "", 2, true);
 
-	$urls = package_dll::getDllDownloadUrls($pkg['name'], $version, $pkg['releases'][$version]['releasedate']);
+	$urls = PackageDll::getDllDownloadUrls($pkg['name'], $version, $pkg['releases'][$version]['releasedate']);
 	if (!$urls) {
 		$bb->fullRow("No DLL available");
 	} else {
 		foreach ($urls as $desc => $set) {
 			$links = [];
 			foreach ($set as $url) {
-				$link_txt = package_dll::makeNiceLinkNameFromZipName(basename($url));
+				$link_txt = PackageDll::makeNiceLinkNameFromZipName(basename($url));
 				$links[] = "<a href=\"$url\">$link_txt</a>";
 			}
 			$bb->horizHeadRow("PHP $desc", implode("<br/>", $links));
@@ -322,7 +322,7 @@ if (!$relid) {
                 $downloads_html .= "<a href=\"/get/$dl[basename]\">".
                                    "$dl[basename]</a> (".sprintf("%.1fkB",@filesize($dl['fullpath'])/1024.0).")";
 
-				$urls = package_dll::getDllDownloadUrls($pkg['name'], $r_version, $pkg['releases'][$r_version]['releasedate']);
+				$urls = PackageDll::getDllDownloadUrls($pkg['name'], $r_version, $pkg['releases'][$r_version]['releasedate']);
 				if ($urls) {
 					$downloads_html .= "&nbsp;&nbsp;<a href=\"/package/$pkg[name]/$r_version/windows\">"
 									. "<img src=\"/gifs/windows-icon.png\" />DLL</a>";

--- a/public_html/package-info.php
+++ b/public_html/package-info.php
@@ -291,7 +291,7 @@ if (!$relid) {
                 $downloads_html .= "<a href=\"/get/$dl[basename]\">".
                                    "$dl[basename]</a> (".sprintf("%.1fkB",@filesize($dl['fullpath'])/1024.0).")";
 
-				$urls = package_dll::getDllDownloadUrls($pkg['name'], $r_version, $pkg['releases'][$r_version]['releasedate']);
+				$urls = PackageDll::getDllDownloadUrls($pkg['name'], $r_version, $pkg['releases'][$r_version]['releasedate']);
 				if ($urls) {
 					$downloads_html .= "&nbsp;&nbsp;<a href=\"/package/$pkg[name]/$r_version/windows\">"
 									. "<img src=\"/gifs/windows-icon.png\" />DLL</a>";

--- a/src/PackageDll.php
+++ b/src/PackageDll.php
@@ -24,11 +24,8 @@ define("PECL_DLL_URL_CACHE_DB_RESET_LOCK", PEAR_TMPDIR . DIRECTORY_SEPARATOR . "
 
 /**
  * Class to handle package DLL builds
- *
- * @class   package_dll
- * @package pearweb
  */
-class package_dll
+class PackageDll
 {
 	protected static $build_gap = 7200; /* 2 hours */
 


### PR DESCRIPTION
This patch moves the package_dll class from include directory to src and renames it to PackageDll.