### PR TITLE
Refactor make_image() template helper

### DIFF
--- a/include/pear-format-html.php
+++ b/include/pear-format-html.php
@@ -26,7 +26,6 @@ PEAR::setErrorHandling(PEAR_ERROR_CALLBACK, "error_handler");
 $extra_styles = [];
 
 require_once 'Net/URL2.php';
-require_once __DIR__.'/layout.php';
 require_once __DIR__.'/../src/BorderBox.php';
 
 $GLOBALS['main_menu'] = [
@@ -60,7 +59,8 @@ $GLOBALS['_style'] = '';
 
 function response_header($title = 'The PHP Extension Community Library', $style = false)
 {
-    global $_style, $_header_done, $SIDEBAR_DATA, $extra_styles, $auth_user;
+    global $_style, $_header_done, $SIDEBAR_DATA, $extra_styles, $auth_user, $imageSize;
+
     if ($_header_done) {
         return;
     }
@@ -122,7 +122,7 @@ echo '<?xml version="1.0" encoding="ISO-8859-1" ?>';
 <table class="head" cellspacing="0" cellpadding="0" width="100%">
  <tr>
   <td class="head-logo">
-    <a href="/"><?php echo make_image('peclsmall.gif', 'PECL :: The PHP Extension Community Library', false, false, false, false, 'margin: 5px;'); ?></a><br />
+    <a href="/"><img src="/gifs/peclsmall.gif" alt="PECL :: The PHP Extension Community Library" <?= $imageSize->getSize('/gifs/peclsmall.gif'); ?> style="margin: 5px;"></a><br>
   </td>
 
   <td class="head-menu">

--- a/include/pear-prepend.php
+++ b/include/pear-prepend.php
@@ -45,9 +45,11 @@ require_once __DIR__.'/../src/Rest.php';
 require_once __DIR__.'/../src/PackageDll.php';
 require_once __DIR__.'/../src/Utils/Filesystem.php';
 require_once __DIR__.'/../src/Utils/FormatDate.php';
+require_once __DIR__.'/../src/Utils/ImageSize.php';
 
 use App\Utils\Filesystem;
 use App\Utils\FormatDate;
+use App\Utils\ImageSize;
 
 function get($name)
 {
@@ -73,6 +75,7 @@ if (empty($dbh)) {
 
 $filesystem = new Filesystem();
 $formatDate = new FormatDate();
+$imageSize = new ImageSize();
 
 if (!isset($rest)) {
     if (!DEVBOX) {

--- a/public_html/account-info.php
+++ b/public_html/account-info.php
@@ -111,7 +111,7 @@ print "<br />\n";
 
 display_user_notes($handle, "100%");
 
-print "<br /><a href=\"/account-edit.php?handle=$handle\">". make_image("edit.gif", "Edit") . "</a>";
+print '<br><a href="/account-edit.php?handle='.htmlspecialchars($handle, ENT_QUOTES).'"><img src="/gifs/edit.gif" alt="Edit"></a>';
 
 print "</td></tr></table>\n";
 

--- a/public_html/admin/index.php
+++ b/public_html/admin/index.php
@@ -331,7 +331,7 @@ do {
                               sprintf('<span style="cursor: hand" onmousedown="highlightAccountRow(this)">%s</span>', nl2br($account_purpose)),
                               sprintf('<span style="cursor: hand" onmousedown="highlightAccountRow(this)">%s</span>', ($rejected ? "rejected" : "<font color=\"#c00000\"><strong>Outstanding</strong></font>")),
                               sprintf('<span style="cursor: hand" onmousedown="highlightAccountRow(this)">%s</span>', $created_at),
-                              sprintf('<span style="cursor: hand" onmousedown="highlightAccountRow(this)">%s</span>', "<a onmousedown=\"event.cancelBubble = true\" href=\"" . htmlspecialchars($_SERVER['PHP_SELF'], ENT_QUOTES) . "?acreq=$handle\">" . make_image("edit.gif") . "</a>")
+                              sprintf('<span style="cursor: hand" onmousedown="highlightAccountRow(this)">%s</span>', '<a onmousedown="event.cancelBubble = true" href="'.htmlspecialchars($_SERVER['PHP_SELF'], ENT_QUOTES).'?acreq='.htmlspecialchars($handle, ENT_QUOTES).'"><img src="/gifs/edit.gif" alt="Edit"></a>')
                               );
             }
 

--- a/public_html/package-edit.php
+++ b/public_html/package-edit.php
@@ -276,7 +276,7 @@ foreach ($row['releases'] as $version => $release) {
     $msg = "Are you sure that you want to delete the release?";
 
     echo "<a href=\"javascript:confirmed_goto('$url', '$msg')\">"
-         . make_image("delete.gif")
+         . '<img src="/gifs/delete.gif" alt="Delete">'
          . "</a>\n";
 
     echo "</td>\n";

--- a/public_html/package-info-win.php
+++ b/public_html/package-info-win.php
@@ -205,9 +205,9 @@ if ($relid) {
 if (!empty($auth_user)) {
     $bb->fullRow("<div align=\"right\">" .
                  '<a href="/package-edit.php?id='.$pacid.'">'.
-                           make_image("edit.gif", "Edit package information").'</a>'.
+                           '<img src="/gifs/edit.gif" alt="Edit package information"></a>'.
                  ($auth_user->isAdmin() ? '&nbsp;<a href="/package-delete.php?id='.$pacid.'">'.
-                                      make_image("delete.gif", "Delete package").'</a>' : '') .
+                                      '<img src="/gifs/delete.gif" alt="Delete package"></a>' : '').
                  '&nbsp;[<a href="/admin/package-maintainers.php?pid='.$pacid.'">Edit maintainers</a>]</div>');
 }
 

--- a/public_html/package-info.php
+++ b/public_html/package-info.php
@@ -199,9 +199,9 @@ if ($relid) {
 if (!empty($auth_user)) {
     $bb->fullRow("<div align=\"right\">" .
                  '<a href="/package-edit.php?id='.$pacid.'">'.
-                           make_image("edit.gif", "Edit package information").'</a>'.
+                           '<img src="/gifs/edit.gif" alt="Edit package information"></a>'.
                  ($auth_user->isAdmin() ? '&nbsp;<a href="/package-delete.php?id='.$pacid.'">'.
-                                      make_image("delete.gif", "Delete package") : '') .
+                                      '<img src="/gifs/delete.gif" alt="Delete package"></a>' : '').
                  '&nbsp;[<a href="/admin/package-maintainers.php?pid='.$pacid.'">Edit maintainers</a>]</div>');
 }
 

--- a/public_html/packages.php
+++ b/public_html/packages.php
@@ -163,7 +163,7 @@ while ($sth->fetchInto($row)) {
     }
 
     if (sizeof($sub_links) >= $max_sub_links) {
-        $sub_links = implode(', ', $sub_links) . ' ' . make_image("caret-r.gif", "[more]");
+        $sub_links = implode(', ', $sub_links).' <img src="/gifs/caret-r.gif" alt="[more]">';
     } else {
         $sub_links = implode(', ', $sub_links);
     }

--- a/public_html/support.php
+++ b/public_html/support.php
@@ -158,7 +158,7 @@ echo '<table cellpadding="5" cellspacing="1">';
 
 foreach ($icons as $file => $desc) {
     echo '<tr bgcolor="e0e0e0">';
-    echo '<td>' . make_image($file,$desc) . '<br></td>';
+    echo '<td><img src="/gifs/'.$file.'" alt="'.$desc.'"><br></td>';
     echo '<td>' . $desc . '<br><small>';
     $size = @getimagesize($_SERVER['DOCUMENT_ROOT'].'/gifs/'.$file);
     if ($size) {

--- a/src/Utils/ImageSize.php
+++ b/src/Utils/ImageSize.php
@@ -18,36 +18,34 @@
   +----------------------------------------------------------------------+
 */
 
+namespace App\Utils;
+
 /**
- * Returns an IMG tag for a given file (relative to the images dir)
+ * Helper class to determine image size.
  */
-function make_image($file, $alt = '', $align = '', $extras = '', $dir = '',
-                    $border = 0, $styles = '')
+class ImageSize
 {
-    if (!$dir) {
-        $dir = '/gifs';
+    private $documentRoot;
+
+    /**
+     * Class constructor.
+     */
+    public function __construct()
+    {
+        $this->documentRoot = realpath(__DIR__.'/../../public_html');
     }
-    if ($size = @getimagesize($_SERVER['DOCUMENT_ROOT'].$dir.'/'.$file)) {
-        $image = sprintf('<img src="%s/%s" style="border: %d;%s%s" %s alt="%s" %s />',
-            $dir,
-            $file,
-            $border,
-            ($styles ? ' '.$styles            : ''),
-            ($align  ? ' float: '.$align.';'  : ''),
-            $size[3],
-            ($alt    ? $alt : ''),
-            ($extras ? ' '.$extras            : '')
-        );
-    } else {
-        $image = sprintf('<img src="%s/%s" style="border: %d;%s%s" alt="%s" %s />',
-            $dir,
-            $file,
-            $border,
-            ($styles ? ' '.$styles            : ''),
-            ($align  ? ' float: '.$align.';'  : ''),
-            ($alt    ? $alt : ''),
-            ($extras ? ' '.$extras            : '')
-        );
+
+    /**
+     * Returns image size attributes (width="..." height="...").
+     */
+    public function getSize($file)
+    {
+        $path = $this->documentRoot.$file;
+
+        if (file_exists($path) && ($size = @getimagesize($path))) {
+            return $size[3];
+        }
+
+        return '';
     }
-    return $image;
 }

--- a/tests/Utils/ImageSizeTest.php
+++ b/tests/Utils/ImageSizeTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Peter Kokot <petk@php.net>                                  |
+  +----------------------------------------------------------------------+
+*/
+
+namespace App\Tests\Utils;
+
+use PHPUnit\Framework\TestCase;
+use App\Utils\ImageSize;
+
+class ImageSizeTest extends TestCase
+{
+    private $imageSize;
+
+    public function setUp()
+    {
+        $this->imageSize = new ImageSize();
+    }
+
+    /**
+     * @dataProvider dateProvider
+     */
+    public function testGetSize($image, $expected)
+    {
+        $this->assertEquals($expected, $this->imageSize->getSize($image));
+    }
+
+    public function dateProvider()
+    {
+        return [
+            ['/gifs/peclsmall.gif', 'width="106" height="55"'],
+            ['/nonexisting/nonexisting.gif', ''],
+            ['/notimage/../composer.json', ''],
+        ];
+    }
+}


### PR DESCRIPTION
This patch refactors function make_image() into a class and adds a unit
test. Several unnecessary make_image() calls have been refactored into a
plain HTML instead since the size attributes are not needed on them
exactly.