### PR TITLE
Refactor get_license_link() into a class

### DIFF
--- a/include/pear-format-html.php
+++ b/include/pear-format-html.php
@@ -454,46 +454,6 @@ function localRedirect($url)
     exit;
 }
 
-/**
- * Get URL to license text
- *
- * @todo  Add more licenses here
- * @param string Name of the license
- * @return string Link to license URL
- */
-function get_license_link($license = "")
-{
-    switch ($license) {
-
-        case 'PHP License':
-        case 'PHP 3.01':
-        case 'PHP License 3.01':
-            $link = 'https://php.net/license/3_01.txt';
-            break;
-
-        case 'PHP 3.0':
-        case 'PHP License 3.0':
-            $link = 'https://php.net/license/3_0.txt';
-            break;
-
-        case 'PHP 2.02':
-        case 'PHP License 2.02':
-            $link = 'https://php.net/license/2_02.txt';
-            break;
-
-        case 'LGPL':
-        case 'GNU Lesser General Public License':
-            $link = 'https://www.gnu.org/licenses/lgpl.html';
-            break;
-
-        default:
-            $link = '';
-            break;
-    }
-
-    return ($link != '' ? '<a href="' . $link . '">' . $license . "</a>\n" : $license);
-}
-
 function display_user_notes($user, $width = '50%')
 {
     global $dbh;

--- a/public_html/package-info-win.php
+++ b/public_html/package-info-win.php
@@ -19,6 +19,12 @@
   +----------------------------------------------------------------------+
 */
 
+require_once __DIR__.'/../src/Utils/Licenser.php';
+
+use App\Utils\Licenser;
+
+$licenser = new Licenser();
+
 $package = filter_input(INPUT_GET, 'package', FILTER_SANITIZE_STRING);
 $version = filter_input(INPUT_GET, 'version', FILTER_SANITIZE_STRING);
 $relid = filter_input(INPUT_GET, FILTER_VALIDATE_INT);
@@ -178,7 +184,7 @@ $bb = new BorderBox("Package Information", "90%", "", 2, true);
 
 $bb->horizHeadRow("Summary", $summary);
 $bb->horizHeadRow("Maintainers", $accounts);
-$bb->horizHeadRow("License", get_license_link($license));
+$bb->horizHeadRow("License", $licenser->getHtml($license));
 $bb->horizHeadRow("Description", nl2br($description));
 
 if (!empty($homepage)) {

--- a/public_html/package-info.php
+++ b/public_html/package-info.php
@@ -19,6 +19,12 @@
   +----------------------------------------------------------------------+
 */
 
+require_once __DIR__.'/../src/Utils/Licenser.php';
+
+use App\Utils\Licenser;
+
+$licenser = new Licenser();
+
 $package = filter_input(INPUT_GET, 'package', FILTER_SANITIZE_STRING);
 $version = filter_input(INPUT_GET, 'version', FILTER_SANITIZE_STRING);
 $relid = filter_input(INPUT_GET, FILTER_VALIDATE_INT);
@@ -172,7 +178,7 @@ $bb = new BorderBox("Package Information", "90%", "", 2, true);
 
 $bb->horizHeadRow("Summary", $summary);
 $bb->horizHeadRow("Maintainers", $accounts);
-$bb->horizHeadRow("License", get_license_link($license));
+$bb->horizHeadRow("License", $licenser->getHtml($license));
 $bb->horizHeadRow("Description", nl2br($description));
 
 if (!empty($homepage)) {

--- a/src/Utils/Licenser.php
+++ b/src/Utils/Licenser.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors:                                                             |
+  +----------------------------------------------------------------------+
+*/
+
+namespace App\Utils;
+
+/**
+ * Helper utility class to get URL by given license name.
+ *
+ * @param string Name of the license
+ */
+class Licenser
+{
+    /**
+     * Returns a link to license by its name.
+     */
+    public function getUrl($license)
+    {
+        switch ($license) {
+            case 'PHP License':
+            case 'PHP 3.01':
+            case 'PHP License 3.01':
+            case 'PHP':
+                return 'https://php.net/license/3_01.txt';
+            break;
+            case 'PHP 3.0':
+            case 'PHP License 3.0':
+                return 'https://php.net/license/3_0.txt';
+            break;
+            case 'PHP 2.02':
+            case 'PHP License 2.02':
+                return 'https://php.net/license/2_02.txt';
+            break;
+            case 'LGPL':
+            case 'GNU Lesser General Public License':
+                return 'https://www.gnu.org/licenses/lgpl.html';
+            break;
+        }
+
+        return '';
+    }
+
+    /**
+     * Get possible HTML anchor element from the given license name.
+     */
+    public function getHtml($license = '')
+    {
+        $url = $this->getUrl($license);
+
+        return ($url != '' ? '<a href="'.$url.'">'.$license.'</a>' : $license);
+    }
+}

--- a/tests/Utils/LicenserTest.php
+++ b/tests/Utils/LicenserTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Peter Kokot <petk@php.net>                                  |
+  +----------------------------------------------------------------------+
+*/
+
+namespace App\Tests\Utils;
+
+use PHPUnit\Framework\TestCase;
+use App\Utils\Licenser;
+
+class LicenserTest extends TestCase
+{
+    private $licenser;
+
+    public function setUp()
+    {
+        $this->licenser = new Licenser();
+    }
+
+    /**
+     * @dataProvider dateProvider
+     */
+    public function testGetLink($license, $expected)
+    {
+        $this->assertEquals($expected, $this->licenser->getHtml($license));
+    }
+
+    public function dateProvider()
+    {
+        return [
+            ['PHP', '<a href="https://php.net/license/3_01.txt">PHP</a>'],
+            ['PHP License', '<a href="https://php.net/license/3_01.txt">PHP License</a>'],
+            ['PHP 3.0', '<a href="https://php.net/license/3_0.txt">PHP 3.0</a>'],
+            ['GNU Lesser General Public License', '<a href="https://www.gnu.org/licenses/lgpl.html">GNU Lesser General Public License</a>'],
+            ['MIT', 'MIT'],
+            ['', ''],
+        ];
+    }
+}


### PR DESCRIPTION
This patch refactors a function get_license_link() into a class Licenser.