### PR TITLE
Refactor PEAR_CHANNELNAME

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -23,6 +23,15 @@
  */
 
 return [
+    // Application environment (dev for development, prod for production, etc.)
+    'env' => 'prod',
+
     // Regex pattern for matching valid PECL accounts usernames
     'valid_usernames_regex' => '/^[a-z][a-z0-9]+$/i',
+
+    // PECL channel URL scheme (http or https)
+    'scheme' => 'https',
+
+    // PECL channel URL host (domain name)
+    'host' => 'pecl.php.net',
 ];

--- a/generatePECL_REST.php
+++ b/generatePECL_REST.php
@@ -20,16 +20,18 @@
 */
 
 /**
- * Generate static REST files for pecl.php.net from existing data
+ * Generate static REST files for PECL from existing data
  */
 
-// Useful files to have
-set_include_path(__DIR__.'/include'.PATH_SEPARATOR.get_include_path());
-
-ob_start();
+// Application configuration
 require_once __DIR__.'/include/pear-config.php';
+require_once __DIR__.'/src/Config.php';
 
-if ($_SERVER['SERVER_NAME'] != PEAR_CHANNELNAME) {
+use App\Config;
+
+$config = new Config(__DIR__.'/config/app.php');
+
+if ($config->get('env') != 'prod') {
     error_reporting(E_ALL);
     define('DEVBOX', true);
 } else {
@@ -66,10 +68,12 @@ if (!isset($rest)) {
         $restDir = __DIR__.'/public_html/rest';
     }
 
-    $rest = new Rest($restDir, $dbh, $filesystem);
+    $rest = new Rest($dbh, $filesystem);
+    $rest->setDirectory($restDir);
+    $rest->setScheme($config->get('scheme'));
+    $rest->setHost($config->get('host'));
 }
 
-ob_end_clean();
 PEAR::setErrorHandling(PEAR_ERROR_DIE);
 
 $filesystem->delete($restDir);

--- a/include/pear-config.php
+++ b/include/pear-config.php
@@ -64,5 +64,3 @@ if (isset($_SERVER['PEAR_REST_DIR'])) {
 } else {
     define('PEAR_REST_DIR', '/var/lib/peclweb/rest');
 }
-
-define('PEAR_CHANNELNAME', 'pecl.php.net');

--- a/include/pear-prepend.php
+++ b/include/pear-prepend.php
@@ -87,7 +87,10 @@ if (!isset($rest)) {
         $restDir = __DIR__.'/../public_html/rest';
     }
 
-    $rest = new Rest($restDir, $dbh, $filesystem);
+    $rest = new Rest($dbh, $filesystem);
+    $rest->setDirectory($restDir);
+    $rest->setScheme($config->get('scheme'));
+    $rest->setHost($config->get('host'));
 }
 
 $tmp = filectime($_SERVER['SCRIPT_FILENAME']);

--- a/public_html/account-request.php
+++ b/public_html/account-request.php
@@ -174,7 +174,7 @@ if (isset($_POST['submit'])) {
                    "Need php.net Account: " . (@$needsvn ? "yes" : "no") . "\n".
                    "Purpose:\n".
                    "$purpose\n\n".
-                   "To handle: http://" . PEAR_CHANNELNAME . "/admin/?acreq={$handle}\n";
+                   'To handle: '.$config->get('scheme').'://'.$config->get('host')."/admin/?acreq={$handle}\n";
 
             if ($moreinfo) {
                 $msg .= "\nMore info:\n$moreinfo\n";

--- a/public_html/feeds/feeds.php
+++ b/public_html/feeds/feeds.php
@@ -28,8 +28,9 @@ function rss_bailout() {
     exit();
 }
 
+
 // If file is given, the file will be used to store the rss feed
-function rss_create($items, $channel_title, $channel_description, $dest_file=false) {
+function rss_create($items, $channel_title, $channel_description, $dest_file=false, $config) {
     if (is_array($items) && count($items)>0) {
 
         $rss_top = <<<EOT
@@ -51,7 +52,7 @@ EOT;
 
             // Allows to override the default link
             if (!isset($item['link'])) {
-                $url = 'http://' . PEAR_CHANNELNAME . '/package-changelog.php?package=' . $item['name'] . '&amp;release=' . $item['version'];
+                $url = $config->get('scheme').'://'.$config->get('host').'/package-changelog.php?package=' . $item['name'] . '&amp;release=' . $item['version'];
             } else {
                 $url = $item['link'];
             }
@@ -172,4 +173,4 @@ switch ($type) {
 // We do not use yet static files. It will be activated with the new backends.
 // $file = __DIR__ . '/' .  $type . '_' . $argument . '.rss';
 $file = false;
-rss_create($items, $channel_title, $channel_description, $file);
+rss_create($items, $channel_title, $channel_description, $file, $config);

--- a/public_html/package-info-win.php
+++ b/public_html/package-info-win.php
@@ -166,7 +166,7 @@ if (!is_null($apply_rule) && isset($dec_messages[$apply_rule])) {
     $str  = '<div class="warnings">';
     $str .= $dec_messages[$apply_rule];
 
-        if ($pkg['new_channel'] == PEAR_CHANNELNAME) {
+        if ($pkg['new_channel'] == $config->get('host')) {
             $str .= '  Use <a href="/package/' . $pkg['new_package'] .
                 '">' . htmlspecialchars($pkg['new_package']) . '</a> instead.';
         } elseif ($pkg['new_channel']) {

--- a/public_html/package-info.php
+++ b/public_html/package-info.php
@@ -160,7 +160,7 @@ if (!is_null($apply_rule) && isset($dec_messages[$apply_rule])) {
     $str  = '<div class="warnings">';
     $str .= $dec_messages[$apply_rule];
 
-        if ($pkg['new_channel'] == PEAR_CHANNELNAME) {
+        if ($pkg['new_channel'] == $config->get('host')) {
             $str .= '  Use <a href="/package/' . $pkg['new_package'] .
                 '">' . htmlspecialchars($pkg['new_package']) . '</a> instead.';
         } elseif ($pkg['new_channel']) {

--- a/src/Rest.php
+++ b/src/Rest.php
@@ -33,15 +33,40 @@ class Rest
     private $dir;
     private $dbh;
     private $filesystem;
+    private $scheme = 'http';
+    private $host;
 
     /**
      * Class constructor.
      */
-    public function __construct($dir, $dbh, Filesystem $filesystem)
+    public function __construct($dbh, Filesystem $filesystem)
     {
-        $this->dir = $dir;
         $this->dbh = $dbh;
         $this->filesystem = $filesystem;
+    }
+
+    /**
+     * Set where to generate XML files.
+     */
+    public function setDirectory($dir)
+    {
+        $this->dir = $dir;
+    }
+
+    /**
+     * Set the scheme of the URL (http or https).
+     */
+    public function setScheme($scheme)
+    {
+        $this->scheme = $scheme;
+    }
+
+    /**
+     * Set the host of the URL for linking to packages.
+     */
+    public function setHost($host)
+    {
+        $this->host = $host;
     }
 
     /**
@@ -64,7 +89,7 @@ class Rest
     xmlns:xlink="http://www.w3.org/1999/xlink"
     xsi:schemaLocation="http://pear.php.net/dtd/rest.allcategories
     http://pear.php.net/dtd/rest.allcategories.xsd">
-<ch>' . PEAR_CHANNELNAME . '</ch>
+<ch>'.$this->host.'</ch>
 ';
         foreach ($categories as $category) {
             $info .= ' <c xlink:href="' . $extra . 'c/' .
@@ -110,7 +135,7 @@ class Rest
     xsi:schemaLocation="http://pear.php.net/dtd/rest.category
     http://pear.php.net/dtd/rest.category.xsd">
  <n>' . htmlspecialchars($category['name']) . '</n>
- <c>' . PEAR_CHANNELNAME . '</c>
+ <c>'.$this->host.'</c>
  <a>' . htmlspecialchars($category['name']) . '</a>
  <d>' . $category['description'] . '</d>
 </c>';
@@ -247,7 +272,7 @@ class Rest
     xmlns:xlink="http://www.w3.org/1999/xlink"
     xsi:schemaLocation="http://pear.php.net/dtd/rest.allpackages
     http://pear.php.net/dtd/rest.allpackages.xsd">
-<c>' . PEAR_CHANNELNAME . '</c>
+<c>'.$this->host.'</c>
 ';
         foreach (Package::listAllNames() as $package)
         {
@@ -317,7 +342,7 @@ class Rest
         $package['description'] = htmlspecialchars($package['description']);
         $info = $this->getPackageProlog() . '
  <n>' . $package['name'] . '</n>
- <c>' . PEAR_CHANNELNAME . '</c>
+ <c>'.$this->host.'</c>
  <ca xlink:href="' . $extra . 'c/' . htmlspecialchars(urlencode($catinfo)) . '">' .
         htmlspecialchars($catinfo) . '</ca>
  <l>' . $package['license'] . '</l>
@@ -357,7 +382,7 @@ class Rest
 '    xsi:schemaLocation="http://pear.php.net/dtd/rest.allreleases' . "\n" .
 '    http://pear.php.net/dtd/rest.allreleases.xsd">' . "\n" .
 ' <p>' . $package . '</p>' . "\n" .
-' <c>' . PEAR_CHANNELNAME . '</c>' . "\n";
+' <c>'.$this->host.'</c>'."\n";
     }
 
     /**
@@ -526,7 +551,7 @@ class Rest
     xsi:schemaLocation="http://pear.php.net/dtd/rest.release
     http://pear.php.net/dtd/rest.release.xsd">
  <p xlink:href="' . $extra . 'p/' . strtolower($package) . '">' . $package . '</p>
- <c>' . PEAR_CHANNELNAME . '</c>
+ <c>'.$this->host.'</c>
  <v>' . $pkgobj->getVersion() . '</v>
  <st>' . $pkgobj->getState() . '</st>
  <l>' . $pkgobj->getLicense() . '</l>
@@ -536,7 +561,7 @@ class Rest
  <da>' . $releasedate . '</da>
  <n>' . htmlspecialchars($pkgobj->getNotes()) . '</n>
  <f>' . filesize($filepath) . '</f>
- <g>http://' . PEAR_CHANNELNAME . '/get/' . $package . '-' . $pkgobj->getVersion() . '</g>
+ <g>'.$this->scheme.'://'.$this->host.'/get/'.$package.'-'.$pkgobj->getVersion().'</g>
  <x xlink:href="package.' . $pkgobj->getVersion() . '.xml"/>
 </r>';
         file_put_contents($packageDir.'/'.$pkgobj->getVersion().'.xml', $info);
@@ -588,7 +613,7 @@ class Rest
     xsi:schemaLocation="http://pear.php.net/dtd/rest.packagemaintainers
     http://pear.php.net/dtd/rest.packagemaintainers.xsd">
  <p>' . $package . '</p>
- <c>' . PEAR_CHANNELNAME . '</c>
+ <c>'.$this->host.'</c>
 ';
             foreach ($maintainers as $maintainer) {
                 $info .= ' <m><h>' . $maintainer['handle'] . '</h><a>' . $maintainer['active'] .


### PR DESCRIPTION
This patch removes the PEAR_CHANNELNAME constant and moves it into a host configuration setting together with some other refactorings tied to this.