### PR TITLE
Remove obsolete pear packages functionality

### DIFF
--- a/public_html/error/404.php
+++ b/public_html/error/404.php
@@ -42,17 +42,7 @@ $pkg = strtr($_SERVER['REDIRECT_URL'], '-','_');
 // Check strictly
 $name = $packageEntity->info(basename($pkg), 'name');
 if (!PEAR::isError($name) && !empty($name)) {
-    if (!empty($name)) {
-        localRedirect('/package/'.urlencode($name));
-    } else {
-        $name = $packageEntity->info(basename($pkg), 'name', true);
-        if (!empty($name)) {
-            header('HTTP/1.0 301 Moved Permanently');
-            header('Location: https://pear.php.net/package/' . $name);
-            header('Connection: close');
-            exit();
-        }
-    }
+    localRedirect('/package/'.urlencode($name));
 }
 
 // Check less strictly if nothing has been found previously

--- a/public_html/package-stats.php
+++ b/public_html/package-stats.php
@@ -137,7 +137,7 @@ $bb->end();
 
 if (isset($_GET['pid']) && (int)$_GET['pid']) {
 
-    $info = $packageEntity->info($_GET['pid'],null,false);
+    $info = $packageEntity->info($_GET['pid'], null);
 
     if (isset($info['releases']) && count($info['releases'])>0) {
         echo '<h2>&raquo; Statistics for Package &quot;<a href="/package/' . $info['name'] . '">' . $info['name'] . "</a>&quot;</h2>\n";

--- a/src/Entity/Maintainer.php
+++ b/src/Entity/Maintainer.php
@@ -25,7 +25,7 @@
 namespace App\Entity;
 
 use App\Entity\Package;
-use App\User;
+use App\User as BaseUser;
 use App\Database;
 use App\Rest;
 use \PEAR as PEAR;
@@ -84,7 +84,7 @@ class Maintainer
      */
     public function add($package, $user, $role, $active = 1)
     {
-        if (!User::exists($user)) {
+        if (!BaseUser::exists($user)) {
             return PEAR::raiseError("User $user does not exist");
         }
 
@@ -162,7 +162,7 @@ class Maintainer
      */
     private function remove($package, $user)
     {
-        if (!$this->authUser->isAdmin() && !User::maintains($this->authUser->handle, $package, 'lead')) {
+        if (!$this->authUser->isAdmin() && !BaseUser::maintains($this->authUser->handle, $package, 'lead')) {
             return PEAR::raiseError('Maintainer::remove: insufficient privileges');
         }
 
@@ -192,7 +192,8 @@ class Maintainer
             return PEAR::raiseError('Maintainer::updateAll: insufficient privileges');
         }
 
-        $pkg_name = $this->package->info((int)$pkgid, "name", true); // Needed for logging
+        // Needed for logging
+        $pkg_name = $this->package->info((int)$pkgid, "name");
 
         if (empty($pkg_name)) {
             PEAR::raiseError('Maintainer::updateAll: no such package');
@@ -282,7 +283,7 @@ class Maintainer
     {
         $admin = $this->authUser->isAdmin();
 
-        if (!$admin && !User::maintains($this->authUser->handle, $package, 'lead')) {
+        if (!$admin && !BaseUser::maintains($this->authUser->handle, $package, 'lead')) {
             return false;
         }
 

--- a/src/Entity/Package.php
+++ b/src/Entity/Package.php
@@ -137,10 +137,9 @@ class Package
      *
      * @param  mixed   Name of the package or it's ID
      * @param  string  Single field to fetch
-     * @param  boolean Should PEAR packages also be taken into account?
      * @return mixed
      */
-    public function info($pkg, $field = null, $allow_pear = false)
+    public function info($pkg, $field = null)
     {
         if (is_numeric($pkg)) {
             $what = "id";
@@ -148,13 +147,7 @@ class Package
             $what = "name";
         }
 
-        $package_type = '';
-
-        if ($allow_pear) {
-             $package_type = "((p.package_type = 'pear' AND p.approved = 1) OR p.package_type = 'pecl') AND ";
-        } else {
-             $package_type = "p.package_type = 'pecl' AND ";
-        }
+        $package_type = "p.package_type = 'pecl' AND ";
 
         $pkg_sql = "SELECT p.id AS packageid, p.name AS name, ".
              "p.package_type AS type, ".

--- a/src/Release.php
+++ b/src/Release.php
@@ -418,7 +418,7 @@ class Release
      */
     public function HTTPdownload($package, $version = null, $file = null, $uncompress = false)
     {
-        $package_id = $this->package->info($package, 'packageid', true);
+        $package_id = $this->package->info($package, 'packageid');
 
         // If no package id has been set, check if this is package alias maybe
         if (!$package_id) {


### PR DESCRIPTION
The Release::info() method third argument returned also packages that are defined as type pear. This is no longer the case with current pecl.php.net packages so this patch removes this for more simplicity.