### PR TITLE
Sync valid PECL extension names

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -94,4 +94,7 @@ return [
      * For example, 18M and 16M.
      */
     'max_file_size' => 16 * 1024 * 1024,
+
+    // Regex pattern for matching valid PECL extension names.
+    'valid_extension_name_regex' => '/^[a-z][a-z0-9_]+$/i',
 ];

--- a/public_html/package-new.php
+++ b/public_html/package-new.php
@@ -21,10 +21,6 @@
 use App\Repository\CategoryRepository;
 use App\Repository\PackageRepository;
 
-if (!defined('PEAR_COMMON_PACKAGE_NAME_PREG')) {
-    define('PEAR_COMMON_PACKAGE_NAME_PREG', '/^([A-Z][a-zA-Z0-9_]+|[a-z][a-z0-9_]+)$/');
-}
-
 $auth->secure();
 
 $display_form = true;
@@ -62,9 +58,8 @@ do {
               break;
           }
 
-        if (!preg_match(PEAR_COMMON_PACKAGE_NAME_PREG, $_POST['name'])) {
-            display_error("Invalid package name.  PECL package names must be ".
-                          "all-lowercase, starting with a letter.");
+        if (!preg_match($config->get('valid_extension_name_regex'), $_POST['name'])) {
+            display_error('Invalid package name. PECL package names must start with a letter and preferably include only lowercase letters. Optionally, numbers and underscores are also allowed.');
             break;
         }
 


### PR DESCRIPTION
This syncs valid extension names when adding a new extension or editing existing extensions. According to the error message in the new-package form only names with lowercase letters or numbers and starting with a lowercase letter were allowed.

Since there are currently lots of existing extensions with uppercase letters used, the edit form allows this edge case also.