### PR TITLE
Fix #64897: different username length

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -73,6 +73,15 @@ return [
     // Packages directory
     'packages_dir' => isset($_SERVER['PECL_PACKAGES_DIR']) ? $_SERVER['PECL_PACKAGES_DIR'] : __DIR__.'/../public_html/packages',
 
-    // Regex pattern for matching valid PECL accounts usernames
-    'valid_usernames_regex' => '/^[a-z][a-z0-9]+$/i',
+    /**
+     * Regex pattern for matching valid PECL accounts usernames
+     */
+    'valid_usernames_regex' => '/^[a-z][a-z0-9]+$/',
+
+    /**
+     * Maximum username length is limited by the main PHP usernames database
+     * field size of varchar(16) in the web/master application at
+     * https://git.php.net/?p=web/master.git
+     */
+    'max_username_length' => 16,
 ];

--- a/public_html/account-request.php
+++ b/public_html/account-request.php
@@ -92,6 +92,11 @@ if (isset($_POST['submit'])) {
                 break;
             }
 
+            if (strlen($handle) > $config->get('max_username_length')) {
+                display_error('Username is too long. It must have '.$config->get('max_username_length').' characters or less.');
+                break;
+            }
+
             if ($password != $password2) {
                 display_error("Passwords did not match");
                 $password = $password2 = "";
@@ -352,7 +357,7 @@ if ($display_form) {
 
     print "<form action=\"" . htmlspecialchars($_SERVER['PHP_SELF']) . "\" method=\"post\" name=\"request_form\">\n";
     $bb = new BorderBox("Request a PECL account", "90%", "", 2, true);
-    $bb->horizHeadRow("Username:", '<input type="text" name="handle" value="'.$handle.'" size="12" />');
+    $bb->horizHeadRow("Username:", '<input type="text" name="handle" value="'.$handle.'" size="12" required maxlength="'.$config->get('max_username_length').'">');
     $bb->horizHeadRow("First Name:", '<input type="text" name="firstname" value="'.$firstname.'" size="20" />');
     $bb->horizHeadRow("Last Name:", '<input type="text" name="lastname" value="'.$lastname.'" size="20" />');
     $bb->horizHeadRow("Password:", '<input type="password" name="password" value="" size="10" />   Again: <input type="password" name="password2" value="" size="10" />');


### PR DESCRIPTION
The username length limit on pecl.php.net and master.php.net were different and this syncs it with master.php.net to 16 characters long.

Fixes [#64897](https://bugs.php.net/bug.php?id=64897)