### PR TITLE
Add Extractor utility

### DIFF
--- a/bin/generate-rest.php
+++ b/bin/generate-rest.php
@@ -23,13 +23,13 @@
  * Generate static REST files for PECL from existing data
  */
 
+use App\Utils\Extractor;
 use App\Repository\CategoryRepository;
 use App\Repository\PackageRepository;
 use App\Repository\UserRepository;
 use \PEAR as PEAR;
 use \PEAR_Config as PEAR_Config;
 use \PEAR_PackageFile as PEAR_PackageFile;
-use \Archive_Tar as Archive_Tar;
 
 require_once __DIR__.'/../include/bootstrap.php';
 
@@ -98,10 +98,10 @@ foreach ($packageRepository->listAll() as $package => $info) {
                 continue;
             }
 
-            $tar = new Archive_Tar($fileinfo);
+            $extractor = new Extractor($fileinfo);
 
-            if ($pxml = $tar->extractInString('package2.xml')) {
-            } elseif ($pxml = $tar->extractInString('package.xml'));
+            if ($pxml = $extractor->getFileContents('package2.xml')) {
+            } elseif ($pxml = $extractor->getFileContents('package.xml'));
 
             PEAR::pushErrorHandling(PEAR_ERROR_RETURN);
             $pf = $pkg->fromAnyFile($fileinfo, PEAR_VALIDATE_NORMAL);

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,9 @@
         "ext-json": "*",
         "ext-pdo": "*",
         "ext-pdo_mysql": "*",
-        "ext-session": "*"
+        "ext-phar": "*",
+        "ext-session": "*",
+        "ext-zlib": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "05a4169bbe57a7b5bedc7cb1902def47",
+    "content-hash": "b847b9ebec5ae4aad33c918862ee35c8",
     "packages": [],
     "packages-dev": [
         {
@@ -1730,7 +1730,9 @@
         "ext-json": "*",
         "ext-pdo": "*",
         "ext-pdo_mysql": "*",
-        "ext-session": "*"
+        "ext-phar": "*",
+        "ext-session": "*",
+        "ext-zlib": "*"
     },
     "platform-dev": []
 }

--- a/include/bootstrap.php
+++ b/include/bootstrap.php
@@ -94,7 +94,6 @@ if ($config->get('env') === 'dev') {
 require_once 'PEAR.php';
 require_once 'PEAR/Config.php';
 require_once 'PEAR/PackageFile/Parser/v2.php';
-require_once 'Archive/Tar.php';
 require_once 'PEAR/PackageFile.php';
 
 // Set application default time zone to UTC for all dates.

--- a/src/Fixtures/AppFixtures.php
+++ b/src/Fixtures/AppFixtures.php
@@ -247,6 +247,7 @@ class AppFixtures
     {
         return '
             admin;John Doe;;1
+            user;Jane Doe;;0
             alexmerz;Alexander Merz;;0
             chregu;Christian Stocker;;0
             cox;Tomas V.V.Cox;;1

--- a/src/Release.php
+++ b/src/Release.php
@@ -28,8 +28,8 @@ use App\Entity\Package;
 use App\User;
 use App\Database;
 use App\Rest;
+use App\Utils\Extractor;
 use \PEAR as PEAR;
-use \Archive_Tar as Archive_Tar;
 use \PEAR_PackageFile as PEAR_PackageFile;
 use \PEAR_Config as PEAR_Config;
 
@@ -221,11 +221,11 @@ class Release
      */
     private function confirmUpload($package, $version, $state, $relnotes, $md5sum, $package_id, $file)
     {
-        $tar = new Archive_Tar($file);
+        $extractor = new Extractor($file);
 
-        $oldpackagexml = $tar->extractInString('package.xml');
-        if (($packagexml = $tar->extractInString('package2.xml'))
-            || ($packagexml = $tar->extractInString('package.xml'))
+        $oldpackagexml = $extractor->getFileContents('package.xml');
+        if (($packagexml = $extractor->getFileContents('package2.xml'))
+            || ($packagexml = $extractor->getFileContents('package.xml'))
         ) {
             // success
         } else {

--- a/src/Utils/Extractor.php
+++ b/src/Utils/Extractor.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Peter Kokot <petk@php.net>                                  |
+  +----------------------------------------------------------------------+
+*/
+
+namespace App\Utils;
+
+/**
+ * Extractor utility to get contents of a file from a tar gzip archive.
+ */
+class Extractor
+{
+    /**
+     * Tar gzip (.tgz or tar.gz) archive file.
+     */
+    private $archive;
+
+    /**
+     * Class constructor.
+     */
+    public function __construct($archive)
+    {
+        $this->archive = $archive;
+    }
+
+    /**
+     * Get contents of file in archive.
+     */
+    public function getFileContents($file)
+    {
+        $stream = 'phar://'.$this->archive.'/'.$file;
+
+        if (!file_exists($stream)) {
+            return false;
+        }
+
+        return file_get_contents($stream);
+    }
+}

--- a/tests/Utils/ExtractorTest.php
+++ b/tests/Utils/ExtractorTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+  +----------------------------------------------------------------------+
+  | The PECL website                                                     |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1999-2018 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://php.net/license/3_01.txt                                     |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Peter Kokot <petk@php.net>                                  |
+  +----------------------------------------------------------------------+
+*/
+
+namespace App\Tests\Utils;
+
+use PHPUnit\Framework\TestCase;
+use App\Utils\Extractor;
+
+class ExtractorTest extends TestCase
+{
+    public function testGetFileContents()
+    {
+        $extractor = new Extractor(__DIR__.'/../fixtures/files/hello.tgz');
+
+        $this->assertEquals(
+            file_get_contents(__DIR__.'/../fixtures/files/hello/config.m4'),
+            $extractor->getFileContents('hello/config.m4')
+        );
+    }
+}

--- a/tests/fixtures/files/hello/package.xml
+++ b/tests/fixtures/files/hello/package.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package packagerversion="1.9.4" version="2.0"
+        xmlns="http://pear.php.net/dtd/package-2.0"
+        xmlns:tasks="http://pear.php.net/dtd/tasks-1.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://pear.php.net/dtd/tasks-1.0 http://pear.php.net/dtd/tasks-1.0.xsd http://pear.php.net/dtd/package-2.0 http://pear.php.net/dtd/package-2.0.xsd">
+    <name>hello</name>
+    <channel>pecl.php.net</channel>
+    <summary>Hello world PECL extension.</summary>
+    <description>
+        Hello world PECL extension has been created for testing pecl website and
+        various command line tools.
+    </description>
+    <lead>
+        <name>John Doe</name>
+        <user>admin</user>
+        <email>admin@example.com</email>
+        <active>yes</active>
+    </lead>
+    <developer>
+        <name>Jane Doe</name>
+        <user>user</user>
+        <email>user@example.com</email>
+        <active>yes</active>
+    </developer>
+    <date>2018-12-06</date>
+    <time>15:00:00</time>
+    <version>
+        <release>0.1.0</release>
+        <api>1.0</api>
+    </version>
+    <stability>
+        <release>stable</release>
+        <api>stable</api>
+    </stability>
+    <license uri="https://php.net/license/3_01.txt">PHP license</license>
+    <notes>
+        + Initial Hello world extension created
+    </notes>
+    <contents>
+        <dir name="/">
+            <file role="src" name=".gitignore" />
+            <file role="src" name="config.m4" />
+            <file role="src" name="config.w32" />
+            <file role="src" name="hello.c" />
+            <file role="src" name="php_hello.h" />
+            <file role="doc" name="README.md" />
+            <file role="test" name="tests/001.phpt" />
+            <file role="test" name="tests/002.phpt" />
+            <file role="test" name="tests/003.phpt" />
+        </dir>
+    </contents>
+    <dependencies>
+        <required>
+            <php>
+                <min>7.3.0</min>
+            </php>
+            <pearinstaller>
+                <min>1.10.7</min>
+            </pearinstaller>
+        </required>
+    </dependencies>
+    <providesextension>hello</providesextension>
+    <extsrcrelease>
+        <configureoption default="no" name="enable-debug-log" prompt="Do you want to enable debug log?" />
+    </extsrcrelease>
+</package>


### PR DESCRIPTION
This patch adds extractor service class for retrieving file contents from the tar gzip archives (tgz). Instead of a pure PHP implementation Archive_Tar PEAR package it uses Phar and zlib extensions to retrieve contents from the phar stream.