### PR TITLE
Fixes issue with Category Package Info REST response

### DIFF
--- a/src/Rest.php
+++ b/src/Rest.php
@@ -235,10 +235,10 @@ class Rest
 
             if (file_exists($rdir.'/'.strtolower($package['name']).'/allreleases.xml')) {
                 $fullpackageinfo .= str_replace(
-                    $this->getAllReleasesRESTProlog($package['name']), '
-<a>
-',
-                file_get_contents($rdir.'/'.strtolower($package['name']).'/allreleases.xml'));
+                    '<?xml version="1.0" encoding="UTF-8" ?>',
+                    '',
+                    file_get_contents($rdir.'/'.strtolower($package['name']).'/allreleases.xml')
+                );
 
                 $dirhandle = opendir($rdir.'/'.strtolower($package['name']));
 


### PR DESCRIPTION
Fixes error:
```
error on line 118 at column 10: XML declaration allowed only at the start of the document
```
for REST response: https://pecl.php.net/rest/c/Authentication/packagesinfo.xml

**Testing notes**
1. Create site database
1. Load fixtures
```bash
bin/console app:generate-fixtures
```
3. Create new release for one package:
```sql
INSERT INTO pecl.releases (id, package, version, state, doneby, license, summary, description, releasedate, releasenotes, packagefile) VALUES (1, 65, '1.0.0', 'stable', 'some', 'MIT', 'bla bla', 'blabla', '2019-02-10 22:50:39', 'reaerfae', 'ert');
```
4. Generate REST
```bash
bin/generate-rest.php
```