### PR TITLE
Make explicit that 'Verify Release' button actually releases

### DIFF
--- a/templates/forms/release_verify.php
+++ b/templates/forms/release_verify.php
@@ -53,7 +53,7 @@ foreach ($vars as $key => $var) {
 
         <?php // Don't show the next step button when errors found ?>
         <?php if (!count($vars['errors'])): ?>
-            <input type="submit" name="verify" value="Verify Release">
+            <input type="submit" name="verify" value="Verify and Release">
         <?php endif; ?>
 
         <input type="submit" name="cancel" value="Cancel">


### PR DESCRIPTION
The text of the HTML button that is used to do a release is 'Verify Release'.

What I get from it, is that it 'verifies a release' (e.g. in this context that verifies that the package I provided is good) rather than it 'performs a release'.

This PR changes the text simply adding a 'and' so it makes more clear that 2 actions will be executed, not one.