### PR TITLE
Update minimum PHP version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Source code of this application is structured in the following directories:
 
 ## Installation
 
-The pecl.php.net is written for PHP 5.6+, MySQL, and Apache 2.4.
+The pecl.php.net is written for PHP 7.2+, MySQL, and Apache 2.4.
 
 ### 1. Dependencies
 


### PR DESCRIPTION
In composer.json we have that the minimum PHP version is 7.2: let's do the same in README.md