### PR TITLE
Sort releases in XML files by version instead of date

### DIFF
--- a/src/Rest.php
+++ b/src/Rest.php
@@ -442,6 +442,11 @@ class Rest
             return;
         }
 
+        // See https://marc.info/?m=168137915918907
+        if ($this->canSortReleasesByVersion($releases)) {
+            $releases = $this->sortReleasesByVersion($releases);
+        }
+
         $info = $this->getAllReleasesRESTProlog($package);
 
         foreach ($releases as $release) {
@@ -735,5 +740,27 @@ class Rest
 
         file_put_contents($mdir.'/allmaintainers.xml', $info);
         @chmod($mdir.'/allmaintainers.xml', 0666);
+    }
+
+    private function canSortReleasesByVersion(array $releases): bool
+    {
+        foreach ($releases as $release) {
+            $version = $release['version'];
+            if (!is_string($version) || !preg_match('/^\\d+(\\.\\d+)*([a-zA-Z]+\\d*)?$/', $version)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private function sortReleasesByVersion(array $releases): array
+    {
+        usort(
+            $releases,
+            static function (array $a, array $b): int {
+                return version_compare($b['version'], $a['version']);
+            }
+        );
+        return $releases;
     }
 }


### PR DESCRIPTION
I've started [this discussion](https://marc.info/?m=168137915918907) in the pecl-dev mailing list, but no one replied to it 😢 Let's see if we can start the discussion here instead... :wink:

We can install PHP extensions by fetching them from the PECL website with

```
pecl install <package-handle>[-<spec>]
```

Where <spec> can be:

- a stability state ([`snapshot`, `devel`, `alpha`, `beta`, or `stable`](https://github.com/pear/pear-core/blob/ed08e2b2200980d9787211f81655f11f491d22dc/PEAR/Registry.php#L2322))
- a version [marching `^\d+(\.\d+)*([a-zA-Z]+\d*)?$`](https://github.com/pear/pear-core/blob/ed08e2b2200980d9787211f81655f11f491d22dc/PEAR/Registry.php#L2326)

if `<spec>` is not specified, [it's assumed to be `stable`](https://github.com/pear/pear-core/blob/ed08e2b2200980d9787211f81655f11f491d22dc/PEAR/Config.php#L217)

When pecl resolves the actual version to be installed, it fetches `http://pecl.php.net/rest/r/<package-handle>/allreleases.xml` and returns the first version that's exactly the version specified, or has at least the stability specified ([see here](https://github.com/pear/pear-core/blob/ed08e2b2200980d9787211f81655f11f491d22dc/PEAR/REST/10.php#L89)).

The versions in the `allreleases.xml` file are [sorted by the release date](https://github.com/php/web-pecl/blob/706b4b0e4e3186f513ada25a283d84df7f8e0286/src/Rest.php#L430).

That way, pecl considers as the "last" stable version the most recent one.

This works fine for packages that are published in a "linear" way.

Problems arise when there are multiple versions maintained for a package (grpc and protobuf are good examples).

For example, protobuf maintainers published version 3.21.6 on 2022-09-13 and version 3.18.3 one day later.
So, [in its `allreleases.xml`](https://pecl.php.net/rest/r/protobuf/allreleases.xml) we have that 3.18.3 comes before 3.21.6, and pecl would have picked up the former instead of the latter.
And this is a big problem: [users aren't installing the most recent "stable" version](https://github.com/protocolbuffers/protobuf/issues/10619).

I think that the easiest and cleanest solution would be to fix the code that generates the `allreleases.xml` file: it should sort the versions with the `version_compare()` PHP function.

PS: is this PR gets merged, someone who has access should regenerate the `allreleases.xml` files for every package published on the PECL archive (I **think** by executing the `bin/generate-rest.php` file).