### PR TITLE
Don't expect TS only extensions to have NTS builds

### DIFF
--- a/src/PackageDll.php
+++ b/src/PackageDll.php
@@ -100,6 +100,8 @@ class PackageDll
         ],
     ];
 
+    private $ts_only_dlls = ['parallel', 'pthreads'];
+
     /**
      * Class constructor.
      */
@@ -230,7 +232,8 @@ class PackageDll
     }
 
     /**
-     * Need always both ts/nts for each branch.
+     * Need always both ts/nts for each branch,
+     * except for explicitly listed ts only exts.
      */
     private function getZipFileList($name, $version)
     {
@@ -247,7 +250,9 @@ class PackageDll
                 if (!isset($ret[$branch][$set["arch"]])) {
                     $ret[$branch][$set["arch"]] = [];
                 }
-                $ret[$branch][$set["arch"]][] = strtolower($pref . "-nts-" . $suf);
+                if (!in_array($name, $this->ts_only_dlls, true)) {
+                    $ret[$branch][$set["arch"]][] = strtolower($pref . "-nts-" . $suf);
+                }
                 $ret[$branch][$set["arch"]][] = strtolower($pref . "-ts-" . $suf);
             }
         }


### PR DESCRIPTION
As it is now, only DLLs of extensions which have been built for NTS and ZTS are shown on the respective extension page.  This has probably been done to avoid "broken" extensions to be shown, to avoid confusion for users ("where are the ZTS builds?"), and likely to endorse NTS builds for security (ASLR) and stability reasons.

However, there are some extensions which do not support NTS builds by design, and I don't see a particularly good reason not to show their DLLs.  To avoid issues with extensions which are supposed to be compatible with NTS and ZTS, we hard-code the list of extensions which are supposed to work in thread-safe mode only.

---

Note that I had committed this patch as 9d7578a3396c03e1fc58156f9f7c8753aab24f78 long ago, but was told to revert it by Anatol. Since a lot of time has passed, I suggest to re-apply the patch to avoid unnecessary work like https://github.com/krakjoe/parallel/pull/273, just because no DLLs are shown on https://pecl.php.net/package/parallel, although they are avaible (https://downloads.php.net/~windows/pecl/releases/parallel/1.2.2/).

@shivammathur, what do you think?