### PR TITLE
Add info about new package which superseded an old package

### DIFF
--- a/templates/pages/extension.php
+++ b/templates/pages/extension.php
@@ -27,7 +27,8 @@
 <?php if ($superseded || $unmaintained): ?>
     <div class="warnings">
         <?php if ($superseded && $unmaintained): ?>
-            This package is not maintained anymore and has been superseded.
+            This package is not maintained anymore and has been superseded by
+            <a href="/package/<?= $this->noHtml($package['new_package']) ?>"><?= $this->noHtml($package['new_package']) ?></a>.
         <?php elseif ($superseded && !$unmaintained): ?>
             This package has been superseded, but is still maintained for bugs and security fixes.
         <?php elseif (!$superseded && $unmaintained): ?>


### PR DESCRIPTION
If a PECL package is unmaintained, but superseded by another PECL package, we show the respective linked package name in the warning box.