### PR TITLE
Simplify select category query in Rest::savePackage()

### DIFF
--- a/src/Rest.php
+++ b/src/Rest.php
@@ -353,7 +353,7 @@ class Rest
             @chmod($packageDir, 0777);
         }
 
-        $catinfo = $this->database->run('SELECT c.name AS category_name FROM packages, categories c WHERE
+        $catinfo = $this->database->run('SELECT c.name AS category_name FROM categories c WHERE
             c.id = ?', [$package['categoryid']])->fetch()['category_name'];
         if (isset($package['parent']) && $package['parent']) {
             $parent = '


### PR DESCRIPTION
While I was reading some code in the Rest.php file, I noticed that a query seems to fetch every record in the packages table without actually using them.

Please remark that I didn't check if the new code in this PR is ok (setting up a working development instance of web pecl is a bit a nightmare).