### PR TITLE
Add message about PIE to various common PECL onboarding routes

### DIFF
--- a/templates/includes/pie.php
+++ b/templates/includes/pie.php
@@ -1,0 +1,11 @@
+    <div class="errors">
+        <div>Have you heard about <abbr title="PHP Installer for Extensions">PIE</abbr>?</div>
+        <p style="font-weight: normal;">
+            &#x1F967; PHP Installer for Extensions (PIE) is a new tool that will
+            eventually deprecate PECL. We recommend publishing your extension
+            using PIE instead.
+        </p>
+        <p>
+            Find out more at <a href="https://github.com/php/pie">https://github.com/php/pie</a>.
+        </p>
+    </div>

--- a/templates/pages/account_request.php
+++ b/templates/pages/account_request.php
@@ -6,6 +6,8 @@
 
     <h1>Publishing in PECL</h1>
 
+    <?php $this->insert('includes/pie.php'); ?>
+
     <p>A few reasons why you might apply for a PECL account:</p>
 
     <ul>

--- a/templates/pages/index.php
+++ b/templates/pages/index.php
@@ -4,6 +4,8 @@
 
 <h3>What is PECL?</h3>
 
+<?php $this->insert('includes/pie.php'); ?>
+
 <p>
 <acronym title="PHP Extension Community Library">PECL</acronym> is a repository
 for PHP Extensions, providing a directory of all known extensions and hosting

--- a/templates/pages/package_new.php
+++ b/templates/pages/package_new.php
@@ -5,6 +5,8 @@
 <?php if (!isset($_POST['submit']) || 0 < count($errors)): ?>
     <h1>New package</h1>
 
+    <?php $this->insert('includes/pie.php'); ?>
+
     <p>Use this form to register a new PECL package.</p>
 
     <p><b>Before proceeding</b>, make sure you pick the right name for your

--- a/templates/pages/release_upload.php
+++ b/templates/pages/release_upload.php
@@ -5,6 +5,8 @@
 <?php if ($displayForm): ?>
     <h1>Upload New Release</h1>
 
+    <?php $this->insert('includes/pie.php'); ?>
+
     <?php if ($success): ?>
         <div class="success">
             Version


### PR DESCRIPTION
Adds a notice about PIE to the following pages:

 - PECL homepage
 - Request a new PECL account form
 - Create a new PECL package form
 - Upload a new release form

Example (from the homepage):

<img width="2486" height="1580" alt="image" src="https://github.com/user-attachments/assets/1ef38497-7f77-4858-a75c-2bb04254fc84" />
